### PR TITLE
feat: add Google Calendar appointment popup

### DIFF
--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -5,9 +5,11 @@ import { motion } from 'framer-motion';
 import { ArrowRight, Sparkles } from 'lucide-react';
 import { NeoBadge } from '@/components/ui/NeoBadge';
 import { useTranslations } from 'next-intl';
+import { GoogleCalendarPopup, useGoogleCalendar } from '@/components/ui/GoogleCalendarPopup';
 
 export default function Hero() {
   const t = useTranslations('hero');
+  const { isOpen, openCalendar, closeCalendar } = useGoogleCalendar();
 
   return (
     <section id="home" className="relative min-h-[90vh] md:min-h-screen flex items-center justify-center bg-[#FFFCF2] border-b-4 border-[#000] overflow-hidden">
@@ -94,6 +96,7 @@ export default function Hero() {
             transition={{ duration: 0.6, delay: 0.8 }}
           >
             <button
+              onClick={openCalendar}
               className="inline-flex items-center justify-center gap-2 px-6 py-3 bg-[#0D7EFF] text-white border-3 border-[#000] rounded shadow-brutal transition-all hover:-translate-y-1 hover:shadow-brutal-lg active:translate-y-0 active:shadow-brutal-sm"
               style={{
                 fontFamily: 'Space Grotesk, sans-serif',
@@ -117,6 +120,9 @@ export default function Hero() {
           </motion.div>
         </div>
       </div>
+
+      {/* Google Calendar Popup */}
+      <GoogleCalendarPopup isOpen={isOpen} onClose={closeCalendar} />
     </section>
   );
 }

--- a/components/sections/WorkTogether.tsx
+++ b/components/sections/WorkTogether.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from 'next-intl';
 import { NeoBadge } from '@/components/ui/NeoBadge';
 import { useAnalytics } from '@/lib/hooks/useAnalytics';
 import { Check, Lightbulb, Users, GraduationCap } from 'lucide-react';
+import { GoogleCalendarPopup, useGoogleCalendar } from '@/components/ui/GoogleCalendarPopup';
 
 interface CollaborationCard {
   id: number;
@@ -18,6 +19,7 @@ interface CollaborationCard {
 export default function WorkTogether() {
   const t = useTranslations('workTogether');
   const analytics = useAnalytics();
+  const { isOpen, openCalendar, closeCalendar } = useGoogleCalendar();
 
   const collaborations: CollaborationCard[] = [
     {
@@ -134,17 +136,20 @@ export default function WorkTogether() {
             <p className="text-body-small md:text-body text-white/90 mb-5" style={{ fontFamily: 'Space Grotesk, sans-serif' }}>
               {t('cta.description')}
             </p>
-            <a
-              href="#ask-me"
+            <button
+              onClick={openCalendar}
               className="inline-block px-6 md:px-8 py-3 md:py-4 bg-[#FFD60A] text-[#0A0A0A] border-4 border-[#000] rounded shadow-brutal-sm hover:-translate-y-1 hover:shadow-brutal transition-all"
               style={{ fontFamily: 'Space Grotesk, sans-serif', fontWeight: 700, fontSize: '14px', textTransform: 'uppercase' }}
             >
               {t('cta.button')}
-            </a>
+            </button>
           </div>
         </div>
 
       </div>
+
+      {/* Google Calendar Popup */}
+      <GoogleCalendarPopup isOpen={isOpen} onClose={closeCalendar} />
     </section>
   );
 }

--- a/components/ui/GoogleCalendarPopup.tsx
+++ b/components/ui/GoogleCalendarPopup.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import React, { useEffect } from 'react';
+import { X } from 'lucide-react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+interface GoogleCalendarPopupProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function GoogleCalendarPopup({ isOpen, onClose }: GoogleCalendarPopupProps) {
+  // Prevent body scroll when popup is open
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'unset';
+    }
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, [isOpen]);
+
+  // Close on escape key
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && isOpen) {
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handleEscape);
+    return () => window.removeEventListener('keydown', handleEscape);
+  }, [isOpen, onClose]);
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <>
+          {/* Backdrop */}
+          <motion.div
+            className="fixed inset-0 bg-black/60 z-50 backdrop-blur-sm"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={onClose}
+          />
+
+          {/* Modal */}
+          <motion.div
+            className="fixed inset-4 md:inset-auto md:left-1/2 md:top-1/2 md:-translate-x-1/2 md:-translate-y-1/2 md:w-[90%] md:max-w-[800px] md:h-[90vh] md:max-h-[700px] bg-white border-4 border-[#000] rounded-lg shadow-brutal z-50 flex flex-col"
+            initial={{ opacity: 0, scale: 0.95, y: 20 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.95, y: 20 }}
+            transition={{ type: 'spring', duration: 0.5 }}
+          >
+            {/* Header */}
+            <div className="flex items-center justify-between p-4 md:p-6 border-b-4 border-[#000] bg-[#FFFCF2]">
+              <h2 className="text-h3 md:text-h2 text-[#0A0A0A]" style={{ fontFamily: 'Space Grotesk, sans-serif' }}>
+                Fissa un appuntamento
+              </h2>
+              <button
+                onClick={onClose}
+                className="p-2 hover:bg-[#FFD60A] border-2 border-[#000] rounded transition-all hover:-translate-y-0.5"
+                aria-label="Chiudi"
+              >
+                <X className="w-6 h-6" />
+              </button>
+            </div>
+
+            {/* Google Calendar iframe */}
+            <div className="flex-1 relative overflow-hidden">
+              <iframe
+                src="https://calendar.google.com/calendar/appointments/schedules/AcZssZ2o-5L_7Zfq9aiQIN-euWoqcCltK9bJn_SDa_5XFZHm5OOPXtPCQsramR2k5Memd5_N2DZslh5v?gv=true"
+                className="absolute inset-0 w-full h-full"
+                frameBorder="0"
+                title="Google Calendar Appointment Scheduling"
+              />
+            </div>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+}
+
+// Hook to use the Google Calendar popup
+export function useGoogleCalendar() {
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  const openCalendar = () => setIsOpen(true);
+  const closeCalendar = () => setIsOpen(false);
+
+  return {
+    isOpen,
+    openCalendar,
+    closeCalendar,
+  };
+}


### PR DESCRIPTION
Implementato popup modale per la prenotazione di appuntamenti tramite Google Calendar. Il popup si apre cliccando su:
- "Parliamone" nella sezione Hero
- "Iniziamo la conversazione" nella sezione Work Together

Modifiche:
- Creato componente GoogleCalendarPopup con design neobrutalist
- Integrato useGoogleCalendar hook per gestione stato
- Aggiunto iframe con URL di Google Calendar Appointment Scheduling
- Supporto accessibilità (Esc key, backdrop click, scroll lock)