### PR TITLE
Fix: Allow direct access to /design-system without i18n redirect

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -36,6 +36,11 @@ export async function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
+  // Skip i18n for design-system page (universal access)
+  if (pathname.startsWith('/design-system')) {
+    return NextResponse.next();
+  }
+
   // Apply i18n middleware for public routes
   return intlMiddleware(request);
 }


### PR DESCRIPTION
Added middleware exception to bypass i18n routing for the design-system page, enabling universal access without locale prefix.

The design system page is now accessible at /design-system instead of being redirected to /it/design-system or other localized versions.

This makes the design system documentation universally accessible regardless of language preference.