### PR TITLE
Fix: Apply correct text colors to Button variants for WCAG AA compliance

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -375,6 +375,61 @@
   font-weight: 700;
 }
 
+/* Button variants - typography and colors with proper contrast */
+/* These classes override the global font-heading/font-bold black text rule */
+.button-primary {
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background-color: #0D7EFF;
+  color: white !important;
+}
+
+.button-secondary {
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background-color: #FF006E;
+  color: white !important;
+}
+
+.button-accent {
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background-color: #FFD60A;
+  color: #0A0A0A !important;
+}
+
+.button-outline {
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background-color: transparent;
+  color: #0A0A0A !important;
+}
+
+.dark .button-outline {
+  color: #FAFAFA !important;
+}
+
+.button-ghost {
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background-color: transparent;
+  color: #0A0A0A !important;
+}
+
+.dark .button-ghost {
+  color: #FAFAFA !important;
+}
+
 
 /* Animations */
 @keyframes pulse-spotify {

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -11,7 +11,6 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant = 'primary', size = 'md', disabled, children, ...props }, ref) => {
     const baseStyles = cn(
       'inline-flex items-center justify-center gap-2',
-      'font-heading font-bold uppercase tracking-wider',
       'border-brutal border-brutalist-border rounded-brutal',
       'transition-all duration-200 ease-brutal',
       'focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-primary',
@@ -21,28 +20,28 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 
     const variantStyles = {
       primary: cn(
-        'bg-primary text-white shadow-brutal',
-        'hover:bg-primary-dark hover:shadow-brutal-hover hover:translate-x-[-4px] hover:translate-y-[-4px]',
+        'button-primary shadow-brutal',
+        'hover:bg-primary-600 hover:shadow-brutal-hover hover:translate-x-[-4px] hover:translate-y-[-4px]',
         'active:shadow-brutal-active'
       ),
       secondary: cn(
-        'bg-secondary text-white shadow-brutal',
-        'hover:bg-secondary-dark hover:shadow-brutal-hover hover:translate-x-[-4px] hover:translate-y-[-4px]',
+        'button-secondary shadow-brutal',
+        'hover:bg-secondary-600 hover:shadow-brutal-hover hover:translate-x-[-4px] hover:translate-y-[-4px]',
         'active:shadow-brutal-active'
       ),
       accent: cn(
-        'bg-accent text-brutalist-text-primary shadow-brutal',
-        'hover:bg-accent-dark hover:text-brutalist-text-primary hover:shadow-brutal-hover hover:translate-x-[-4px] hover:translate-y-[-4px]',
+        'button-accent shadow-brutal',
+        'hover:bg-accent-600 hover:shadow-brutal-hover hover:translate-x-[-4px] hover:translate-y-[-4px]',
         'active:shadow-brutal-active'
       ),
       outline: cn(
-        'bg-transparent text-brutalist-text-light dark:text-brutalist-text-dark shadow-brutal',
+        'button-outline shadow-brutal',
         'hover:bg-brutalist-text-light hover:text-brutalist-bg-light hover:shadow-brutal-hover hover:translate-x-[-4px] hover:translate-y-[-4px]',
         'dark:hover:bg-brutalist-text-dark dark:hover:text-brutalist-bg-dark',
         'active:shadow-brutal-active'
       ),
       ghost: cn(
-        'bg-transparent text-brutalist-text-light dark:text-brutalist-text-dark border-transparent shadow-none',
+        'button-ghost border-transparent shadow-none',
         'hover:bg-brutalist-border/5 hover:translate-x-[-2px] hover:translate-y-[-2px]',
         'active:translate-x-[2px] active:translate-y-[2px]'
       ),


### PR DESCRIPTION
Following the NeoBadge pattern, created dedicated CSS classes (button-*) in globals.css to ensure proper text color contrast:

- Primary/Secondary buttons: white text on colored backgrounds
- Accent button: black text on Cyber Yellow (#FFD60A) for readability
- Outline/Ghost buttons: dark mode support with proper text colors

Technical changes:
- Added .button-primary, .button-secondary, .button-accent, .button-outline, .button-ghost classes in globals.css with typography and colors
- Removed font-heading/font-bold from Button baseStyles (caused black text override due to globals.css !important rule)
- Typography now managed by button-* classes matching NeoBadge pattern
- All brutalist styles preserved (borders, shadows, hover effects)

Resolves text contrast violations in Button component.