### PR TITLE
Update Blog Cards Pattern to match Designprototipo

### DIFF
--- a/app/design-system/page.tsx
+++ b/app/design-system/page.tsx
@@ -919,7 +919,7 @@ export default function DesignSystemPage() {
                 Blog Cards Pattern
               </h3>
               <p className="text-body-small text-brutalist-text-secondary mb-6">
-                Neobrutalist blog cards with two layout variants: with description (preview text) or without (compact). Both maintain fixed height for consistent grid layouts.
+                Neobrutalist blog cards following the Designprototipo pattern. Two layout variants: with description (preview text) or without (compact). White background with vertical lift hover animation.
               </p>
 
               {/* With Description */}
@@ -990,35 +990,44 @@ export default function DesignSystemPage() {
                 <h4 className="text-h4 font-heading font-bold text-brutalist-text-primary mb-3">
                   Usage Guidelines
                 </h4>
+                <p className="text-body-small text-brutalist-text-secondary mb-4 italic">
+                  Based on Designprototipo reference: <a href="https://github.com/Selfrules/Designprototipo" target="_blank" rel="noopener noreferrer" className="text-electric-blue underline">BlogSection.tsx Regular Posts</a>
+                </p>
                 <ul className="space-y-3 text-body-small text-brutalist-text-secondary">
                   <li className="flex gap-3">
                     <span className="text-electric-blue font-bold">→</span>
                     <span>
-                      <strong className="text-brutalist-text-primary">Fixed Height:</strong> Both variants use h-[400px] for consistent grid layouts
+                      <strong className="text-brutalist-text-primary">Background:</strong> White background (bg-white) as per prototype, not cream
                     </span>
                   </li>
                   <li className="flex gap-3">
                     <span className="text-neon-pink font-bold">→</span>
                     <span>
-                      <strong className="text-brutalist-text-primary">Title Styling:</strong> Always uppercase with font-black for maximum impact
+                      <strong className="text-brutalist-text-primary">Hover Animation:</strong> Vertical lift only (hover:-translate-y-2), 8px upward movement
                     </span>
                   </li>
                   <li className="flex gap-3">
                     <span className="text-deep-purple font-bold">→</span>
                     <span>
-                      <strong className="text-brutalist-text-primary">Description Truncation:</strong> line-clamp-3 ensures descriptions don't overflow
+                      <strong className="text-brutalist-text-primary">Title Hover:</strong> Title changes color to Electric Blue (#0D7EFF) on card hover
                     </span>
                   </li>
                   <li className="flex gap-3">
                     <span className="text-cyber-yellow font-bold">→</span>
                     <span>
-                      <strong className="text-brutalist-text-primary">Category Variants:</strong> design (Electric Blue), dev (Teal), pm (Deep Purple), tool (Neon Pink), featured (Cyber Yellow)
+                      <strong className="text-brutalist-text-primary">Layout:</strong> Badge inline, metadata footer with top border separator (pt-4 border-t)
                     </span>
                   </li>
                   <li className="flex gap-3">
                     <span className="text-teal font-bold">→</span>
                     <span>
-                      <strong className="text-brutalist-text-primary">Hover Effects:</strong> Uses standard brutalist hover (-4px translate + shadow increase)
+                      <strong className="text-brutalist-text-primary">Description:</strong> line-clamp-3 ensures descriptions don't overflow (only when provided)
+                    </span>
+                  </li>
+                  <li className="flex gap-3">
+                    <span className="text-neon-pink font-bold">→</span>
+                    <span>
+                      <strong className="text-brutalist-text-primary">Category Variants:</strong> design (Electric Blue), dev (Teal), pm (Deep Purple), tool (Neon Pink), featured (Cyber Yellow)
                     </span>
                   </li>
                 </ul>

--- a/components/blog/BlogCard.tsx
+++ b/components/blog/BlogCard.tsx
@@ -40,9 +40,9 @@ export default function BlogCard({ post, locale, featured = false }: BlogCardPro
       <article className="lg:col-span-3">
         <Link href={`/${locale}/blog/${post.slug}`}>
           <motion.div
-            whileHover={{ x: -4, y: -4 }}
+            whileHover={{ y: -8 }}
             transition={{ type: 'spring', stiffness: 300, damping: 20 }}
-            className="bg-gradient-to-br from-electric-blue via-deep-purple to-neon-pink border-brutal shadow-brutal hover:shadow-brutal-hover rounded-brutal bg-white p-brutal-lg md:p-brutal-xl min-h-[300px] md:min-h-[350px] flex flex-col justify-between cursor-pointer relative overflow-hidden"
+            className="bg-gradient-to-br from-electric-blue via-deep-purple to-neon-pink border-brutal shadow-brutal hover:shadow-brutal-lg rounded-brutal-lg bg-white p-brutal-lg md:p-brutal-xl min-h-[300px] md:min-h-[350px] flex flex-col justify-between cursor-pointer relative overflow-hidden"
           >
             {/* Decorative Circle */}
             <div className="absolute -top-20 -right-20 w-64 h-64 bg-white/10 rounded-full" />
@@ -90,9 +90,9 @@ export default function BlogCard({ post, locale, featured = false }: BlogCardPro
   return (
     <Link href={`/${locale}/blog/${post.slug}`}>
       <motion.article
-        whileHover={{ x: -4, y: -4 }}
+        whileHover={{ y: -8 }}
         transition={{ type: 'spring', stiffness: 300, damping: 20 }}
-        className="group bg-white border-brutal shadow-brutal hover:shadow-brutal-hover rounded-brutal cursor-pointer"
+        className="group bg-white border-brutal shadow-brutal hover:shadow-brutal-lg rounded-brutal-lg cursor-pointer"
       >
         <div className="p-brutal-md flex flex-col h-full">
           <div className="mb-auto">

--- a/components/ui/BlogCard.tsx
+++ b/components/ui/BlogCard.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { cn } from '@/lib/utils';
 import { Badge } from '@/components/ui/Badge';
-import { Button } from '@/components/ui/Button';
 import { Calendar, Clock } from 'lucide-react';
 
 export interface BlogCardProps extends React.HTMLAttributes<HTMLDivElement> {

--- a/components/ui/BlogCard.tsx
+++ b/components/ui/BlogCard.tsx
@@ -101,7 +101,7 @@ const BlogCard = React.forwardRef<HTMLDivElement, BlogCardProps>(
         ref={ref}
         className={cn(
           // Base brutalist styles - WHITE BACKGROUND as per prototype
-          'group bg-white border-brutal border-black rounded-lg shadow-brutal',
+          'group bg-white border-brutal border-black rounded-brutal-lg shadow-brutal',
           'transition-all duration-200 ease-brutal',
           // Hover effects - VERTICAL ONLY as per prototype
           'hover:shadow-brutal-lg hover:-translate-y-2',

--- a/components/ui/BlogCard.tsx
+++ b/components/ui/BlogCard.tsx
@@ -9,11 +9,11 @@ export interface BlogCardProps extends React.HTMLAttributes<HTMLDivElement> {
    */
   variant?: 'design' | 'dev' | 'pm' | 'tool' | 'featured';
   /**
-   * Blog post title (displayed in uppercase)
+   * Blog post title
    */
   title: string;
   /**
-   * Optional description (will be truncated with ellipsis)
+   * Optional description (truncated with line-clamp-3)
    */
   description?: string;
   /**
@@ -29,7 +29,7 @@ export interface BlogCardProps extends React.HTMLAttributes<HTMLDivElement> {
    */
   onClick?: () => void;
   /**
-   * Optional href for the CTA button
+   * Optional href for navigation (currently unused but kept for future use)
    */
   href?: string;
 }

--- a/components/ui/BlogCard.tsx
+++ b/components/ui/BlogCard.tsx
@@ -136,7 +136,7 @@ const BlogCard = React.forwardRef<HTMLDivElement, BlogCardProps>(
           <div className="flex-1" />
 
           {/* Metadata Footer - with border-top separator as per prototype */}
-          <div className="pt-4 border-t border-brutal-thin border-black">
+          <div className="pt-brutal-sm border-t border-brutal-thin border-black">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-3 text-body-small text-brutalist-text-tertiary">
                 <span className="flex items-center gap-1.5">

--- a/components/ui/BlogCard.tsx
+++ b/components/ui/BlogCard.tsx
@@ -42,11 +42,16 @@ export interface BlogCardProps extends React.HTMLAttributes<HTMLDivElement> {
  * @category Blog
  *
  * @description
- * Neobrutalist blog card with two layout variants:
- * - With description: Shows truncated preview text
- * - Without description: More compact, focus on title and metadata
+ * Neobrutalist blog card following the Designprototipo pattern with two layout variants:
+ * - With description: Shows truncated preview text (line-clamp-3)
+ * - Without description: Compact layout, focus on title and metadata
  *
- * Both variants maintain the same fixed height for consistent grid layouts.
+ * Pattern specifications (from prototype):
+ * - White background (bg-white) with 4px black border
+ * - Vertical hover animation (lifts up 8px)
+ * - Title changes color to Electric Blue on hover
+ * - Metadata footer separated by top border
+ * - Badge inline with content (not in separate container)
  *
  * @example
  * ```tsx
@@ -60,7 +65,7 @@ export interface BlogCardProps extends React.HTMLAttributes<HTMLDivElement> {
  *   href="/blog/art-of-saying-no"
  * />
  *
- * // Without description
+ * // Without description (compact)
  * <BlogCard
  *   variant="dev"
  *   title="Quick wins: 3 micro-optimizations"
@@ -95,15 +100,11 @@ const BlogCard = React.forwardRef<HTMLDivElement, BlogCardProps>(
       <div
         ref={ref}
         className={cn(
-          // Base brutalist styles
-          'bg-cream border-brutal border-black rounded-brutal shadow-brutal',
+          // Base brutalist styles - WHITE BACKGROUND as per prototype
+          'group bg-white border-brutal border-black rounded-lg shadow-brutal',
           'transition-all duration-200 ease-brutal',
-          // Fixed height for both variants
-          'h-[400px]',
-          // Flex layout for content distribution
-          'flex flex-col',
-          // Hover effects
-          'hover:shadow-brutal-hover hover:translate-x-[-4px] hover:translate-y-[-4px]',
+          // Hover effects - VERTICAL ONLY as per prototype
+          'hover:shadow-brutal-lg hover:-translate-y-2',
           // Clickable cursor
           (onClick || href) && 'cursor-pointer',
           className
@@ -111,17 +112,17 @@ const BlogCard = React.forwardRef<HTMLDivElement, BlogCardProps>(
         onClick={onClick}
         {...props}
       >
-        {/* Badge */}
-        <div className="p-6 pb-4">
-          <Badge variant={variant} size="md">
-            {badgeLabels[variant]}
-          </Badge>
-        </div>
+        {/* Content Area - p-6 as per prototype */}
+        <div className="p-6 flex flex-col h-full">
+          {/* Badge inline */}
+          <div className="mb-4">
+            <Badge variant={variant} size="sm">
+              {badgeLabels[variant]}
+            </Badge>
+          </div>
 
-        {/* Content Area - Flexible */}
-        <div className="px-6 flex-1 flex flex-col">
-          {/* Title */}
-          <h3 className="text-h3 font-heading font-black text-brutalist-text-primary uppercase mb-4 leading-tight">
+          {/* Title - hover changes color as per prototype */}
+          <h3 className="text-body mb-4 text-brutalist-text-primary group-hover:text-electric-blue transition-colors leading-snug font-heading font-bold">
             {title}
           </h3>
 
@@ -132,37 +133,24 @@ const BlogCard = React.forwardRef<HTMLDivElement, BlogCardProps>(
             </p>
           )}
 
-          {/* Spacer to push metadata and CTA to bottom */}
+          {/* Spacer to push metadata to bottom */}
           <div className="flex-1" />
 
-          {/* Metadata */}
-          <div className="flex items-center gap-4 text-brutalist-text-tertiary mb-4">
-            <div className="flex items-center gap-1.5">
-              <Calendar className="w-4 h-4" />
-              <span className="text-body-xs font-mono">{date}</span>
-            </div>
-            <div className="flex items-center gap-1.5">
-              <Clock className="w-4 h-4" />
-              <span className="text-body-xs font-mono">{readingTime} min</span>
+          {/* Metadata Footer - with border-top separator as per prototype */}
+          <div className="pt-4 border-t border-brutal-thin border-black">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-3 text-body-small text-brutalist-text-tertiary">
+                <span className="flex items-center gap-1.5">
+                  <Calendar className="w-4 h-4" />
+                  {date}
+                </span>
+                <span className="flex items-center gap-1.5">
+                  <Clock className="w-4 h-4" />
+                  {readingTime} min
+                </span>
+              </div>
             </div>
           </div>
-        </div>
-
-        {/* CTA Button */}
-        <div className="p-6 pt-0">
-          <Button
-            variant="outline"
-            size="sm"
-            className="w-full uppercase"
-            onClick={(e) => {
-              e.stopPropagation();
-              if (href) {
-                window.location.href = href;
-              }
-            }}
-          >
-            Leggi l'articolo
-          </Button>
         </div>
       </div>
     );


### PR DESCRIPTION
Modified BlogCard component to follow the prototype pattern from Designprototipo repository:

- White background (bg-white) instead of cream
- Vertical hover animation (lifts up 8px) instead of diagonal translation
- Title changes color to Electric Blue on hover (group-hover:text-electric-blue)
- Metadata footer with top border separator (pt-4 border-t)
- Badge inline with content instead of separate container
- Removed CTA button and fixed height constraint
- Removed fixed h-[400px] for more flexible card heights

Updated design-system page documentation with:
- Reference to Designprototipo pattern
- Updated usage guidelines
- Link to prototype repository

Reference: https://github.com/Selfrules/Designprototipo
Component: BlogSection.tsx (Regular Posts section)