### PR TITLE
Fix colored text utilities in design system page

### DIFF
--- a/app/design-system/page.tsx
+++ b/app/design-system/page.tsx
@@ -198,7 +198,7 @@ export default function DesignSystemPage() {
                           {color.use}
                         </p>
                       </div>
-                      <p className={`text-h4 font-heading font-bold text-${color.utility}`}>
+                      <p className="text-h4 font-heading font-bold" style={{ color: color.hex }}>
                         The quick brown fox
                       </p>
                     </div>


### PR DESCRIPTION
The text color classes were not being applied because Tailwind CSS doesn't support dynamically constructed class names with template literals.

Changed from:
- className={`text-${color.utility}`}

To:
- style={{ color: color.hex }}

This ensures the brand colors (Electric Blue, Neon Pink, Cyber Yellow, Deep Purple, Teal) are correctly displayed in the "Colored Text Utilities" section.