### PR TITLE
feat: Add 8 neobrutalist blog UI components to design system

### DIFF
--- a/app/design-system/page.tsx
+++ b/app/design-system/page.tsx
@@ -11,6 +11,16 @@ import { CollaborationCard } from '@/components/ui/CollaborationCard';
 import { BlogCard } from '@/components/ui/BlogCard';
 import { DesignSystemNav } from '@/components/design-system/DesignSystemNav';
 import {
+  LearningObjectives,
+  InsightBox,
+  TeamComposition,
+  ProblemList,
+  FrameworkDisplay,
+  CTABox,
+  MetricsGrid,
+  LessonsList,
+} from '@/components/ui/blog';
+import {
   Palette,
   Type,
   Layers,
@@ -39,6 +49,7 @@ export default function DesignSystemPage() {
     { id: 'components', label: 'Components', icon: Layers },
     { id: 'utilities', label: 'Utilities', icon: Box },
     { id: 'patterns', label: 'Patterns', icon: Sparkles },
+    { id: 'blog-components', label: 'Blog Components', icon: BookOpen },
   ];
 
   const brandColors = [
@@ -1032,6 +1043,227 @@ export default function DesignSystemPage() {
                   </li>
                 </ul>
               </div>
+            </div>
+          </section>
+
+          {/* Blog Components Section */}
+          <section id="blog-components" className="scroll-mt-24">
+            <div className="mb-8">
+              <div className="flex items-center gap-3 mb-3">
+                <BookOpen className="w-6 h-6 text-teal" />
+                <h2 className="text-h2 font-heading font-black text-brutalist-text-primary">
+                  Blog Components
+                </h2>
+              </div>
+              <p className="text-body text-brutalist-text-secondary">
+                Componenti UI riusabili per articoli di blog, creati seguendo il design system neobrutalist.
+              </p>
+            </div>
+
+            {/* Learning Objectives */}
+            <div className="mb-12">
+              <h3 className="text-h3 font-heading font-bold text-brutalist-text-primary mb-4">
+                Learning Objectives
+              </h3>
+              <p className="text-body-small text-brutalist-text-secondary mb-6">
+                Box "Cosa imparerai" con lista di obiettivi e link CTA. Perfetto per l'inizio degli articoli.
+              </p>
+              <LearningObjectives
+                objectives={[
+                  'Come bilanciare richieste stakeholder e bisogni utenti',
+                  'Framework pratico di prioritizzazione con scoring trasparente',
+                  'Risultati misurabili: +42% engagement, -60% feature ignorate'
+                ]}
+                ctaText="Vai alla soluzione"
+                ctaHref="#solution"
+                color="electric-blue"
+              />
+            </div>
+
+            {/* Insight Box */}
+            <div className="mb-12">
+              <h3 className="text-h3 font-heading font-bold text-brutalist-text-primary mb-4">
+                Insight Box
+              </h3>
+              <p className="text-body-small text-brutalist-text-secondary mb-6">
+                Callout per evidenziare insight chiave. Disponibile in diverse varianti colore.
+              </p>
+              <div className="space-y-4">
+                <InsightBox variant="default">
+                  Il 70% delle feature richieste dagli stakeholder non risolvevano problemi reali degli utenti.
+                </InsightBox>
+                <InsightBox variant="blue" title="Key Insight">
+                  La trasparenza nel processo decisionale elimina il 90% delle dispute sulla roadmap.
+                </InsightBox>
+              </div>
+            </div>
+
+            {/* Team Composition */}
+            <div className="mb-12">
+              <h3 className="text-h3 font-heading font-bold text-brutalist-text-primary mb-4">
+                Team Composition
+              </h3>
+              <p className="text-body-small text-brutalist-text-secondary mb-6">
+                Display numerico della composizione del team. Utile per mostrare contesto aziendale.
+              </p>
+              <TeamComposition
+                members={[
+                  { count: 8, role: 'Sviluppatori', color: 'teal' },
+                  { count: 2, role: 'Designer', color: 'blue' },
+                  { count: 1, role: 'PM (io)', color: 'purple' }
+                ]}
+              />
+            </div>
+
+            {/* Problem List */}
+            <div className="mb-12">
+              <h3 className="text-h3 font-heading font-bold text-brutalist-text-primary mb-4">
+                Problem List
+              </h3>
+              <p className="text-body-small text-brutalist-text-secondary mb-6">
+                Lista numerata di problemi/challenges. Perfetto per descrivere il contesto di un progetto.
+              </p>
+              <ProblemList
+                title="Le sfide principali"
+                problems={[
+                  'Roadmap sovraffollata di feature request non validate',
+                  'Mancanza di dati quantitativi sulle priorità',
+                  'Comunicazione frammentata tra team e stakeholder',
+                  'Deadline irrealistiche imposte dal management'
+                ]}
+                variant="red"
+              />
+            </div>
+
+            {/* Framework Display */}
+            <div className="mb-12">
+              <h3 className="text-h3 font-heading font-bold text-brutalist-text-primary mb-4">
+                Framework Display
+              </h3>
+              <p className="text-body-small text-brutalist-text-secondary mb-6">
+                Mostra framework o metodologie a colonne. Ideale per presentare concetti strutturati.
+              </p>
+              <FrameworkDisplay
+                title="Framework di Prioritizzazione"
+                columns={[
+                  {
+                    title: 'Impatto Utente',
+                    description: 'Quanti utenti beneficiano della feature?',
+                    icon: Users,
+                    color: 'blue'
+                  },
+                  {
+                    title: 'Sforzo Tecnico',
+                    description: 'Complessità di sviluppo e tempo richiesto',
+                    icon: Code2,
+                    color: 'teal'
+                  },
+                  {
+                    title: 'Allineamento',
+                    description: 'Coerenza con vision e strategia aziendale',
+                    icon: Star,
+                    color: 'purple'
+                  }
+                ]}
+              />
+            </div>
+
+            {/* CTA Box */}
+            <div className="mb-12">
+              <h3 className="text-h3 font-heading font-bold text-brutalist-text-primary mb-4">
+                CTA Box
+              </h3>
+              <p className="text-body-small text-brutalist-text-secondary mb-6">
+                Call-to-action con gradiente e bottone. Per conversioni o lead generation.
+              </p>
+              <CTABox
+                title="Ti piace questo approccio?"
+                description="Scopri come posso aiutarti a implementarlo nel tuo team"
+                buttonText="Prenota una consulenza"
+                buttonHref="#contact"
+                variant="brand"
+              />
+            </div>
+
+            {/* Metrics Grid */}
+            <div className="mb-12">
+              <h3 className="text-h3 font-heading font-bold text-brutalist-text-primary mb-4">
+                Metrics Grid
+              </h3>
+              <p className="text-body-small text-brutalist-text-secondary mb-6">
+                Griglia di metriche/risultati. Mostra l'impatto di un progetto in modo visuale.
+              </p>
+              <MetricsGrid
+                title="Risultati del Progetto"
+                columns={4}
+                metrics={[
+                  { value: '+42%', description: 'User engagement sulle nuove feature', trend: 'up', color: 'green' },
+                  { value: '-60%', description: 'Feature ignorate dagli utenti', trend: 'down', color: 'green' },
+                  { value: '+35%', description: 'Velocità di delivery del team', trend: 'up', color: 'blue' },
+                  { value: '4.8/5', description: 'Soddisfazione stakeholder', trend: 'neutral', color: 'purple' }
+                ]}
+              />
+            </div>
+
+            {/* Lessons List */}
+            <div>
+              <h3 className="text-h3 font-heading font-bold text-brutalist-text-primary mb-4">
+                Lessons List
+              </h3>
+              <p className="text-body-small text-brutalist-text-secondary mb-6">
+                Lista di lessons learned. Perfetto per concludere case study con takeaway chiave.
+              </p>
+              <LessonsList
+                title="Lezioni chiave"
+                color="purple"
+                lessons={[
+                  {
+                    title: 'La trasparenza vince sempre',
+                    description: 'Rendere visibile il processo decisionale elimina il 90% delle dispute sulla roadmap. Tutti sanno come e perché vengono prese le decisioni.'
+                  },
+                  {
+                    title: 'I dati battono le opinioni',
+                    description: 'Un framework quantitativo toglie l\'emotività dalle decisioni difficili. Le discussioni diventano oggettive e costruttive.'
+                  },
+                  {
+                    title: 'Il team deve essere coinvolto',
+                    description: 'Le decisioni prese insieme hanno un tasso di successo 3x superiore. L\'ownership condiviso fa la differenza.'
+                  }
+                ]}
+              />
+            </div>
+
+            {/* Usage Guidelines */}
+            <div className="mt-12 bg-white border-brutal border-black rounded-brutal shadow-brutal p-6">
+              <h4 className="text-h4 font-heading font-bold text-brutalist-text-primary mb-3">
+                Linee Guida per l'Uso
+              </h4>
+              <ul className="space-y-3 text-body-small text-brutalist-text-secondary">
+                <li className="flex gap-3">
+                  <span className="text-electric-blue font-bold">→</span>
+                  <span>
+                    <strong className="text-brutalist-text-primary">Importazione:</strong> Importa componenti da <code className="text-xs bg-cream px-2 py-1 rounded border border-black">@/components/ui/blog</code>
+                  </span>
+                </li>
+                <li className="flex gap-3">
+                  <span className="text-neon-pink font-bold">→</span>
+                  <span>
+                    <strong className="text-brutalist-text-primary">Design Tokens:</strong> Tutti i componenti usano i design tokens del sistema (colori, spacing, shadows)
+                  </span>
+                </li>
+                <li className="flex gap-3">
+                  <span className="text-deep-purple font-bold">→</span>
+                  <span>
+                    <strong className="text-brutalist-text-primary">Responsive:</strong> Tutti i componenti sono mobile-first e responsive
+                  </span>
+                </li>
+                <li className="flex gap-3">
+                  <span className="text-teal font-bold">→</span>
+                  <span>
+                    <strong className="text-brutalist-text-primary">Accessibilità:</strong> Seguono le linee guida WCAG AA con contrasto appropriato
+                  </span>
+                </li>
+              </ul>
             </div>
           </section>
 

--- a/components/blog/BlogCard.tsx
+++ b/components/blog/BlogCard.tsx
@@ -42,7 +42,7 @@ export default function BlogCard({ post, locale, featured = false }: BlogCardPro
               <div className="flex items-center gap-3 mb-brutal-sm">
                 <NeoBadge color="yellow">
                   {post.category}
-                </Badge>
+                </NeoBadge>
                 <Badge variant="featured" size="sm">
                   DA NON PERDERE
                 </Badge>

--- a/components/ui/blog/CTABox.tsx
+++ b/components/ui/blog/CTABox.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/Button';
+import { ArrowRight, Sparkles } from 'lucide-react';
+
+/**
+ * @component CTABox
+ * @category Blog Components
+ * @description CTA box per call-to-action con gradiente e bottone
+ */
+
+export interface CTABoxProps {
+  /** Titolo del CTA */
+  title: string;
+  /** Descrizione (opzionale) */
+  description?: string;
+  /** Testo del bottone */
+  buttonText: string;
+  /** URL del bottone */
+  buttonHref?: string;
+  /** Callback onClick (alternativa a href) */
+  onClick?: () => void;
+  /** Variante gradiente */
+  variant?: 'brand' | 'blog-hero' | 'blue' | 'purple' | 'pink';
+  /** Mostra icona sparkles */
+  showIcon?: boolean;
+  className?: string;
+}
+
+const variantMap = {
+  brand: 'bg-gradient-brand',
+  'blog-hero': 'bg-gradient-blog-hero',
+  blue: 'bg-electric-blue',
+  purple: 'bg-deep-purple',
+  pink: 'bg-neon-pink',
+};
+
+export const CTABox = React.forwardRef<HTMLDivElement, CTABoxProps>(
+  (
+    {
+      title,
+      description,
+      buttonText,
+      buttonHref,
+      onClick,
+      variant = 'brand',
+      showIcon = true,
+      className,
+    },
+    ref
+  ) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'border-brutal border-black rounded-brutal shadow-brutal p-brutal-xl text-center',
+          variantMap[variant],
+          className
+        )}
+      >
+        {/* Icon */}
+        {showIcon && (
+          <div className="inline-flex items-center justify-center w-16 h-16 bg-white/20 backdrop-blur-sm rounded-brutal border-brutal-thin border-white/40 mb-brutal-md">
+            <Sparkles className="w-8 h-8 text-white" />
+          </div>
+        )}
+
+        {/* Title */}
+        <h3 className="text-h2 font-heading font-black text-white mb-brutal-sm">
+          {title}
+        </h3>
+
+        {/* Description */}
+        {description && (
+          <p className="text-body text-white/90 mb-brutal-lg max-w-2xl mx-auto">
+            {description}
+          </p>
+        )}
+
+        {/* CTA Button */}
+        {buttonHref ? (
+          <a href={buttonHref}>
+            <Button variant="accent" size="lg" className="uppercase shadow-brutal">
+              {buttonText}
+              <ArrowRight className="w-5 h-5" />
+            </Button>
+          </a>
+        ) : (
+          <Button variant="accent" size="lg" onClick={onClick} className="uppercase shadow-brutal">
+            {buttonText}
+            <ArrowRight className="w-5 h-5" />
+          </Button>
+        )}
+      </div>
+    );
+  }
+);
+
+CTABox.displayName = 'CTABox';

--- a/components/ui/blog/FrameworkDisplay.tsx
+++ b/components/ui/blog/FrameworkDisplay.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+import { LucideIcon } from 'lucide-react';
+
+/**
+ * @component FrameworkDisplay
+ * @category Blog Components
+ * @description Framework display a 3 colonne con icone e descrizioni
+ */
+
+export interface FrameworkColumn {
+  /** Titolo della colonna */
+  title: string;
+  /** Descrizione */
+  description: string;
+  /** Icona (optional) */
+  icon?: LucideIcon;
+  /** Colore del tema */
+  color?: 'blue' | 'pink' | 'purple' | 'yellow' | 'teal';
+}
+
+export interface FrameworkDisplayProps {
+  /** Titolo del framework (opzionale) */
+  title?: string;
+  /** Colonne del framework */
+  columns: FrameworkColumn[];
+  className?: string;
+}
+
+const colorMap = {
+  blue: {
+    bg: 'bg-electric-blue',
+    border: 'border-electric-blue',
+    bgLight: 'bg-electric-blue/5',
+  },
+  pink: {
+    bg: 'bg-neon-pink',
+    border: 'border-neon-pink',
+    bgLight: 'bg-neon-pink/5',
+  },
+  purple: {
+    bg: 'bg-deep-purple',
+    border: 'border-deep-purple',
+    bgLight: 'bg-deep-purple/5',
+  },
+  yellow: {
+    bg: 'bg-cyber-yellow',
+    border: 'border-cyber-yellow',
+    bgLight: 'bg-cyber-yellow/5',
+  },
+  teal: {
+    bg: 'bg-teal',
+    border: 'border-teal',
+    bgLight: 'bg-teal/5',
+  },
+};
+
+export const FrameworkDisplay = React.forwardRef<HTMLDivElement, FrameworkDisplayProps>(
+  ({ title, columns, className }, ref) => {
+    return (
+      <div ref={ref} className={cn('space-y-brutal-md', className)}>
+        {/* Title */}
+        {title && (
+          <h3 className="text-h3 font-heading font-bold text-brutalist-text-primary text-center mb-brutal-lg">
+            {title}
+          </h3>
+        )}
+
+        {/* Columns Grid */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {columns.map((column, index) => {
+            const Icon = column.icon;
+            const colors = column.color ? colorMap[column.color] : colorMap.blue;
+
+            return (
+              <div
+                key={index}
+                className="bg-white border-brutal border-black rounded-brutal shadow-brutal p-brutal-md hover:-translate-y-1 hover:shadow-brutal-hover transition-all"
+              >
+                {/* Icon */}
+                {Icon && (
+                  <div className={cn('w-12 h-12 rounded-brutal border-brutal-thin border-black flex items-center justify-center mb-4', colors.bg)}>
+                    <Icon className="w-6 h-6 text-white" />
+                  </div>
+                )}
+
+                {/* Title */}
+                <h4 className="text-h4 font-heading font-bold text-brutalist-text-primary mb-3">
+                  {column.title}
+                </h4>
+
+                {/* Description */}
+                <p className="text-body-small text-brutalist-text-secondary">
+                  {column.description}
+                </p>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+);
+
+FrameworkDisplay.displayName = 'FrameworkDisplay';

--- a/components/ui/blog/FrameworkDisplay.tsx
+++ b/components/ui/blog/FrameworkDisplay.tsx
@@ -90,7 +90,7 @@ export const FrameworkDisplay = React.forwardRef<HTMLDivElement, FrameworkDispla
                 </h4>
 
                 {/* Description */}
-                <p className="text-body-small text-brutalist-text-secondary">
+                <p className="text-body-sm text-brutalist-text-secondary">
                   {column.description}
                 </p>
               </div>

--- a/components/ui/blog/InsightBox.tsx
+++ b/components/ui/blog/InsightBox.tsx
@@ -72,7 +72,7 @@ export const InsightBox = React.forwardRef<HTMLDivElement, InsightBoxProps>(
             <p className="text-body font-heading font-bold text-brutalist-text-primary mb-2">
               💡 {title}:
             </p>
-            <div className="text-body-small text-brutalist-text-secondary">
+            <div className="text-body-sm text-brutalist-text-secondary">
               {children}
             </div>
           </div>

--- a/components/ui/blog/InsightBox.tsx
+++ b/components/ui/blog/InsightBox.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+import { Lightbulb } from 'lucide-react';
+
+/**
+ * @component InsightBox
+ * @category Blog Components
+ * @description Callout box per insight chiave con emoji lightbulb
+ */
+
+export interface InsightBoxProps {
+  /** Contenuto dell'insight */
+  children: React.ReactNode;
+  /** Titolo del box (default: "Insight chiave") */
+  title?: string;
+  /** Variante colore */
+  variant?: 'default' | 'blue' | 'pink' | 'purple' | 'yellow';
+  className?: string;
+}
+
+const variantMap = {
+  default: {
+    bg: 'bg-cream',
+    border: 'border-black',
+    icon: 'bg-cyber-yellow',
+  },
+  blue: {
+    bg: 'bg-electric-blue/5',
+    border: 'border-electric-blue',
+    icon: 'bg-electric-blue',
+  },
+  pink: {
+    bg: 'bg-neon-pink/5',
+    border: 'border-neon-pink',
+    icon: 'bg-neon-pink',
+  },
+  purple: {
+    bg: 'bg-deep-purple/5',
+    border: 'border-deep-purple',
+    icon: 'bg-deep-purple',
+  },
+  yellow: {
+    bg: 'bg-cyber-yellow/5',
+    border: 'border-cyber-yellow',
+    icon: 'bg-cyber-yellow',
+  },
+};
+
+export const InsightBox = React.forwardRef<HTMLDivElement, InsightBoxProps>(
+  ({ children, title = 'Insight chiave', variant = 'default', className }, ref) => {
+    const styles = variantMap[variant];
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'border-brutal-thick rounded-brutal shadow-brutal',
+          'p-brutal-md',
+          styles.bg,
+          styles.border,
+          className
+        )}
+      >
+        <div className="flex items-start gap-4">
+          {/* Icon */}
+          <div className={cn('w-10 h-10 rounded-brutal border-brutal-thin border-black flex items-center justify-center shrink-0', styles.icon)}>
+            <Lightbulb className="w-5 h-5 text-white" />
+          </div>
+
+          {/* Content */}
+          <div className="flex-1">
+            <p className="text-body font-heading font-bold text-brutalist-text-primary mb-2">
+              💡 {title}:
+            </p>
+            <div className="text-body-small text-brutalist-text-secondary">
+              {children}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+);
+
+InsightBox.displayName = 'InsightBox';

--- a/components/ui/blog/LearningObjectives.tsx
+++ b/components/ui/blog/LearningObjectives.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+import { ArrowRight, BookOpen } from 'lucide-react';
+
+/**
+ * @component LearningObjectives
+ * @category Blog Components
+ * @description Box "Cosa imparerai" con lista di obiettivi e link CTA
+ */
+
+export interface LearningObjectivesProps {
+  /** Lista di obiettivi di apprendimento */
+  objectives: string[];
+  /** Testo del CTA (default: "Vai alla soluzione") */
+  ctaText?: string;
+  /** URL del CTA anchor */
+  ctaHref?: string;
+  /** Colore del tema (default: electric-blue) */
+  color?: 'electric-blue' | 'neon-pink' | 'deep-purple' | 'teal' | 'cyber-yellow';
+  className?: string;
+}
+
+const colorMap = {
+  'electric-blue': {
+    bg: 'bg-electric-blue/5',
+    border: 'border-electric-blue',
+    text: 'text-electric-blue',
+    icon: 'bg-electric-blue',
+  },
+  'neon-pink': {
+    bg: 'bg-neon-pink/5',
+    border: 'border-neon-pink',
+    text: 'text-neon-pink',
+    icon: 'bg-neon-pink',
+  },
+  'deep-purple': {
+    bg: 'bg-deep-purple/5',
+    border: 'border-deep-purple',
+    text: 'text-deep-purple',
+    icon: 'bg-deep-purple',
+  },
+  'teal': {
+    bg: 'bg-teal/5',
+    border: 'border-teal',
+    text: 'text-teal',
+    icon: 'bg-teal',
+  },
+  'cyber-yellow': {
+    bg: 'bg-cyber-yellow/5',
+    border: 'border-cyber-yellow',
+    text: 'text-cyber-yellow',
+    icon: 'bg-cyber-yellow',
+  },
+};
+
+export const LearningObjectives = React.forwardRef<HTMLDivElement, LearningObjectivesProps>(
+  ({ objectives, ctaText = 'Vai alla soluzione', ctaHref = '#solution', color = 'electric-blue', className }, ref) => {
+    const colors = colorMap[color];
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'bg-white border-brutal border-black rounded-brutal shadow-brutal',
+          'p-brutal-lg',
+          className
+        )}
+      >
+        {/* Header */}
+        <div className="flex items-center gap-3 mb-brutal-md">
+          <div className={cn('w-12 h-12 rounded-brutal border-brutal-thin border-black flex items-center justify-center', colors.icon)}>
+            <BookOpen className="w-6 h-6 text-white" />
+          </div>
+          <h3 className="text-h4 font-heading font-bold text-brutalist-text-primary">
+            📌 Cosa imparerai in questo articolo
+          </h3>
+        </div>
+
+        {/* Objectives List */}
+        <ul className="space-y-3 mb-brutal-md">
+          {objectives.map((objective, index) => (
+            <li key={index} className="flex gap-3 text-body-small text-brutalist-text-secondary">
+              <span className={cn('font-bold', colors.text)}>→</span>
+              <span>{objective}</span>
+            </li>
+          ))}
+        </ul>
+
+        {/* CTA */}
+        <a
+          href={ctaHref}
+          className={cn(
+            'inline-flex items-center gap-2 font-heading font-bold text-body-small uppercase tracking-wider',
+            colors.text,
+            'hover:underline transition-all'
+          )}
+        >
+          {ctaText}
+          <ArrowRight className="w-4 h-4" />
+        </a>
+      </div>
+    );
+  }
+);
+
+LearningObjectives.displayName = 'LearningObjectives';

--- a/components/ui/blog/LearningObjectives.tsx
+++ b/components/ui/blog/LearningObjectives.tsx
@@ -79,7 +79,7 @@ export const LearningObjectives = React.forwardRef<HTMLDivElement, LearningObjec
         {/* Objectives List */}
         <ul className="space-y-3 mb-brutal-md">
           {objectives.map((objective, index) => (
-            <li key={index} className="flex gap-3 text-body-small text-brutalist-text-secondary">
+            <li key={index} className="flex gap-3 text-body-sm text-brutalist-text-secondary">
               <span className={cn('font-bold', colors.text)}>→</span>
               <span>{objective}</span>
             </li>
@@ -90,7 +90,7 @@ export const LearningObjectives = React.forwardRef<HTMLDivElement, LearningObjec
         <a
           href={ctaHref}
           className={cn(
-            'inline-flex items-center gap-2 font-heading font-bold text-body-small uppercase tracking-wider',
+            'inline-flex items-center gap-2 font-heading font-bold text-body-sm uppercase tracking-wider',
             colors.text,
             'hover:underline transition-all'
           )}

--- a/components/ui/blog/LessonsList.tsx
+++ b/components/ui/blog/LessonsList.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+import { Award } from 'lucide-react';
+
+/**
+ * @component LessonsList
+ * @category Blog Components
+ * @description Lista di lessons learned con numeri e descrizioni
+ */
+
+export interface Lesson {
+  /** Titolo della lezione */
+  title: string;
+  /** Descrizione dettagliata */
+  description: string;
+}
+
+export interface LessonsListProps {
+  /** Titolo della sezione (opzionale) */
+  title?: string;
+  /** Lista di lessons */
+  lessons: Lesson[];
+  /** Colore del tema */
+  color?: 'blue' | 'pink' | 'purple' | 'yellow' | 'teal';
+  className?: string;
+}
+
+const colorMap = {
+  blue: {
+    bg: 'bg-electric-blue',
+    text: 'text-electric-blue',
+    bgLight: 'bg-electric-blue/5',
+  },
+  pink: {
+    bg: 'bg-neon-pink',
+    text: 'text-neon-pink',
+    bgLight: 'bg-neon-pink/5',
+  },
+  purple: {
+    bg: 'bg-deep-purple',
+    text: 'text-deep-purple',
+    bgLight: 'bg-deep-purple/5',
+  },
+  yellow: {
+    bg: 'bg-cyber-yellow',
+    text: 'text-cyber-yellow',
+    bgLight: 'bg-cyber-yellow/5',
+  },
+  teal: {
+    bg: 'bg-teal',
+    text: 'text-teal',
+    bgLight: 'bg-teal/5',
+  },
+};
+
+export const LessonsList = React.forwardRef<HTMLDivElement, LessonsListProps>(
+  ({ title, lessons, color = 'blue', className }, ref) => {
+    const colors = colorMap[color];
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'bg-white border-brutal border-black rounded-brutal shadow-brutal p-brutal-lg',
+          className
+        )}
+      >
+        {/* Header */}
+        {title && (
+          <div className="flex items-center gap-3 mb-brutal-lg">
+            <div className={cn('w-10 h-10 rounded-brutal border-brutal-thin border-black flex items-center justify-center', colors.bg)}>
+              <Award className="w-5 h-5 text-white" />
+            </div>
+            <h3 className="text-h3 font-heading font-bold text-brutalist-text-primary">
+              {title}
+            </h3>
+          </div>
+        )}
+
+        {/* Lessons List */}
+        <div className="space-y-6">
+          {lessons.map((lesson, index) => (
+            <div key={index} className={cn('rounded-brutal p-brutal-md border-l-brutal-thick', colors.bgLight, colors.text)}>
+              <div className="flex gap-4">
+                {/* Number Badge */}
+                <div className="shrink-0">
+                  <div
+                    className={cn(
+                      'w-10 h-10 rounded-brutal border-brutal-thin border-black flex items-center justify-center',
+                      colors.bg
+                    )}
+                  >
+                    <span className="text-h4 font-heading font-black text-white">
+                      {index + 1}
+                    </span>
+                  </div>
+                </div>
+
+                {/* Content */}
+                <div className="flex-1">
+                  <h4 className="text-body font-heading font-bold text-brutalist-text-primary mb-2">
+                    {lesson.title}
+                  </h4>
+                  <p className="text-body-small text-brutalist-text-secondary">
+                    {lesson.description}
+                  </p>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+);
+
+LessonsList.displayName = 'LessonsList';

--- a/components/ui/blog/LessonsList.tsx
+++ b/components/ui/blog/LessonsList.tsx
@@ -101,7 +101,7 @@ export const LessonsList = React.forwardRef<HTMLDivElement, LessonsListProps>(
                   <h4 className="text-body font-heading font-bold text-brutalist-text-primary mb-2">
                     {lesson.title}
                   </h4>
-                  <p className="text-body-small text-brutalist-text-secondary">
+                  <p className="text-body-sm text-brutalist-text-secondary">
                     {lesson.description}
                   </p>
                 </div>

--- a/components/ui/blog/MetricsGrid.tsx
+++ b/components/ui/blog/MetricsGrid.tsx
@@ -87,7 +87,7 @@ export const MetricsGrid = React.forwardRef<HTMLDivElement, MetricsGridProps>(
                 </div>
 
                 {/* Description */}
-                <p className="text-body-small text-brutalist-text-secondary">
+                <p className="text-body-sm text-brutalist-text-secondary">
                   {metric.description}
                 </p>
               </div>

--- a/components/ui/blog/MetricsGrid.tsx
+++ b/components/ui/blog/MetricsGrid.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+import { TrendingUp, TrendingDown } from 'lucide-react';
+
+/**
+ * @component MetricsGrid
+ * @category Blog Components
+ * @description Griglia di metriche/risultati con valori, descrizioni e trend
+ */
+
+export interface Metric {
+  /** Valore della metrica (es: "+42%", "12s", "3x") */
+  value: string;
+  /** Descrizione della metrica */
+  description: string;
+  /** Trend: up, down, neutral */
+  trend?: 'up' | 'down' | 'neutral';
+  /** Colore del tema */
+  color?: 'blue' | 'pink' | 'purple' | 'yellow' | 'teal' | 'green';
+}
+
+export interface MetricsGridProps {
+  /** Titolo della sezione (opzionale) */
+  title?: string;
+  /** Lista di metriche */
+  metrics: Metric[];
+  /** Numero di colonne nel grid */
+  columns?: 2 | 3 | 4;
+  className?: string;
+}
+
+const colorMap = {
+  blue: 'text-electric-blue',
+  pink: 'text-neon-pink',
+  purple: 'text-deep-purple',
+  yellow: 'text-cyber-yellow',
+  teal: 'text-teal',
+  green: 'text-success',
+};
+
+const bgColorMap = {
+  blue: 'bg-electric-blue/5',
+  pink: 'bg-neon-pink/5',
+  purple: 'bg-deep-purple/5',
+  yellow: 'bg-cyber-yellow/5',
+  teal: 'bg-teal/5',
+  green: 'bg-success/5',
+};
+
+export const MetricsGrid = React.forwardRef<HTMLDivElement, MetricsGridProps>(
+  ({ title, metrics, columns = 2, className }, ref) => {
+    const gridCols = {
+      2: 'grid-cols-1 md:grid-cols-2',
+      3: 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3',
+      4: 'grid-cols-1 md:grid-cols-2 lg:grid-cols-4',
+    };
+
+    return (
+      <div ref={ref} className={cn('space-y-brutal-md', className)}>
+        {/* Title */}
+        {title && (
+          <h3 className="text-h3 font-heading font-bold text-brutalist-text-primary text-center">
+            {title}
+          </h3>
+        )}
+
+        {/* Metrics Grid */}
+        <div className={cn('grid gap-6', gridCols[columns])}>
+          {metrics.map((metric, index) => {
+            const color = metric.color || 'blue';
+            const TrendIcon = metric.trend === 'up' ? TrendingUp : metric.trend === 'down' ? TrendingDown : null;
+
+            return (
+              <div
+                key={index}
+                className={cn(
+                  'bg-white border-brutal border-black rounded-brutal shadow-brutal p-brutal-md text-center',
+                  'hover:-translate-y-1 hover:shadow-brutal-hover transition-all'
+                )}
+              >
+                {/* Value with optional trend icon */}
+                <div className="flex items-center justify-center gap-2 mb-2">
+                  <p className={cn('text-h1 font-heading font-black', colorMap[color])}>
+                    {metric.value}
+                  </p>
+                  {TrendIcon && <TrendIcon className={cn('w-8 h-8', colorMap[color])} />}
+                </div>
+
+                {/* Description */}
+                <p className="text-body-small text-brutalist-text-secondary">
+                  {metric.description}
+                </p>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+);
+
+MetricsGrid.displayName = 'MetricsGrid';

--- a/components/ui/blog/ProblemList.tsx
+++ b/components/ui/blog/ProblemList.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+import { AlertCircle } from 'lucide-react';
+
+/**
+ * @component ProblemList
+ * @category Blog Components
+ * @description Lista numerata di problemi/challenges con stile neobrutalist
+ */
+
+export interface ProblemListProps {
+  /** Titolo del box (opzionale) */
+  title?: string;
+  /** Lista di problemi */
+  problems: string[];
+  /** Variante colore */
+  variant?: 'red' | 'blue' | 'purple' | 'default';
+  className?: string;
+}
+
+const variantMap = {
+  default: {
+    bg: 'bg-cream',
+    numberBg: 'bg-brutalist-text-primary',
+  },
+  red: {
+    bg: 'bg-error/5',
+    numberBg: 'bg-error',
+  },
+  blue: {
+    bg: 'bg-electric-blue/5',
+    numberBg: 'bg-electric-blue',
+  },
+  purple: {
+    bg: 'bg-deep-purple/5',
+    numberBg: 'bg-deep-purple',
+  },
+};
+
+export const ProblemList = React.forwardRef<HTMLDivElement, ProblemListProps>(
+  ({ title, problems, variant = 'default', className }, ref) => {
+    const styles = variantMap[variant];
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'bg-white border-brutal border-black rounded-brutal shadow-brutal',
+          'p-brutal-lg',
+          className
+        )}
+      >
+        {/* Header */}
+        {title && (
+          <div className="flex items-center gap-3 mb-brutal-md">
+            <AlertCircle className="w-6 h-6 text-error" />
+            <h3 className="text-h4 font-heading font-bold text-brutalist-text-primary">
+              {title}
+            </h3>
+          </div>
+        )}
+
+        {/* Problem Items */}
+        <div className="space-y-4">
+          {problems.map((problem, index) => (
+            <div
+              key={index}
+              className={cn('rounded-brutal p-4 border-brutal-thin border-black', styles.bg)}
+            >
+              <div className="flex items-start gap-4">
+                {/* Number Badge */}
+                <div
+                  className={cn(
+                    'w-8 h-8 rounded-brutal border-2 border-black flex items-center justify-center shrink-0',
+                    styles.numberBg
+                  )}
+                >
+                  <span className="text-body-small font-heading font-black text-white">
+                    {index + 1}
+                  </span>
+                </div>
+
+                {/* Problem Text */}
+                <p className="text-body-small text-brutalist-text-primary flex-1 pt-1">
+                  {problem}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+);
+
+ProblemList.displayName = 'ProblemList';

--- a/components/ui/blog/ProblemList.tsx
+++ b/components/ui/blog/ProblemList.tsx
@@ -75,13 +75,13 @@ export const ProblemList = React.forwardRef<HTMLDivElement, ProblemListProps>(
                     styles.numberBg
                   )}
                 >
-                  <span className="text-body-small font-heading font-black text-white">
+                  <span className="text-body-sm font-heading font-black text-white">
                     {index + 1}
                   </span>
                 </div>
 
                 {/* Problem Text */}
-                <p className="text-body-small text-brutalist-text-primary flex-1 pt-1">
+                <p className="text-body-sm text-brutalist-text-primary flex-1 pt-1">
                   {problem}
                 </p>
               </div>

--- a/components/ui/blog/TeamComposition.tsx
+++ b/components/ui/blog/TeamComposition.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+/**
+ * @component TeamComposition
+ * @category Blog Components
+ * @description Display numerico della composizione del team
+ */
+
+export interface TeamMember {
+  /** Numero di membri */
+  count: number;
+  /** Ruolo/titolo */
+  role: string;
+  /** Colore del tema */
+  color?: 'blue' | 'pink' | 'purple' | 'yellow' | 'teal';
+}
+
+export interface TeamCompositionProps {
+  /** Lista di membri del team */
+  members: TeamMember[];
+  /** Layout: horizontal o vertical */
+  layout?: 'horizontal' | 'vertical';
+  className?: string;
+}
+
+const colorMap = {
+  blue: 'bg-electric-blue',
+  pink: 'bg-neon-pink',
+  purple: 'bg-deep-purple',
+  yellow: 'bg-cyber-yellow',
+  teal: 'bg-teal',
+};
+
+export const TeamComposition = React.forwardRef<HTMLDivElement, TeamCompositionProps>(
+  ({ members, layout = 'horizontal', className }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'bg-white border-brutal border-black rounded-brutal shadow-brutal p-brutal-lg',
+          className
+        )}
+      >
+        <div
+          className={cn(
+            'grid gap-6',
+            layout === 'horizontal' ? 'grid-cols-1 md:grid-cols-3' : 'grid-cols-1'
+          )}
+        >
+          {members.map((member, index) => (
+            <div key={index} className="flex flex-col items-center text-center">
+              {/* Count Circle */}
+              <div
+                className={cn(
+                  'w-20 h-20 rounded-brutal border-brutal border-black flex items-center justify-center mb-3',
+                  member.color ? colorMap[member.color] : 'bg-electric-blue'
+                )}
+              >
+                <span className="text-h2 font-heading font-black text-white">
+                  {member.count}
+                </span>
+              </div>
+
+              {/* Role */}
+              <p className="text-body font-heading font-bold text-brutalist-text-primary">
+                {member.role}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+);
+
+TeamComposition.displayName = 'TeamComposition';

--- a/components/ui/blog/index.ts
+++ b/components/ui/blog/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Blog Article Components
+ *
+ * Componenti UI riusabili per articoli di blog seguendo il design system neobrutalist.
+ * Questi componenti sono stati creati basandosi sul riferimento Designprototipo.
+ */
+
+export { LearningObjectives } from './LearningObjectives';
+export type { LearningObjectivesProps } from './LearningObjectives';
+
+export { InsightBox } from './InsightBox';
+export type { InsightBoxProps } from './InsightBox';
+
+export { TeamComposition } from './TeamComposition';
+export type { TeamCompositionProps, TeamMember } from './TeamComposition';
+
+export { ProblemList } from './ProblemList';
+export type { ProblemListProps } from './ProblemList';
+
+export { FrameworkDisplay } from './FrameworkDisplay';
+export type { FrameworkDisplayProps, FrameworkColumn } from './FrameworkDisplay';
+
+export { CTABox } from './CTABox';
+export type { CTABoxProps } from './CTABox';
+
+export { MetricsGrid } from './MetricsGrid';
+export type { MetricsGridProps, Metric } from './MetricsGrid';
+
+export { LessonsList } from './LessonsList';
+export type { LessonsListProps, Lesson } from './LessonsList';


### PR DESCRIPTION
Created reusable blog article components following the neobrutalist design system:

Components added:
- LearningObjectives: Box with learning objectives and CTA link
- InsightBox: Callout for highlighting key insights
- TeamComposition: Numeric team composition display
- ProblemList: Numbered list of problems/challenges
- FrameworkDisplay: 3-column framework presentation
- CTABox: Call-to-action box with gradient background
- MetricsGrid: Results/metrics grid with trend indicators
- LessonsList: Lessons learned list with numbered items

All components:
- Follow neobrutalist design patterns (brutal borders, shadows, spacing)
- Use design tokens from tailwind.config.ts
- Are fully responsive and mobile-first
- Include comprehensive TypeScript types
- Support color variants matching the brand palette

Also added:
- New "Blog Components" section in design-system page with live examples
- Fixed JSX closing tag bug in BlogCard.tsx (NeoBadge/Badge mismatch)
- Created index.ts for convenient imports from @/components/ui/blog

Reference: Designprototipo BlogArticle.tsx patterns