### PR TITLE
[HF-007] Mark story as Done - Footer titles already yellow

### DIFF
--- a/.backlog/backlog.md
+++ b/.backlog/backlog.md
@@ -189,7 +189,7 @@ Correggere inconsistenze visive e di contenuto nelle sezioni Homepage (Hero, Jou
 | HF-004 | Update Flowing employment dates | 🟠 | 🟢 S | 🌐 Web | 📋 Todo |
 | HF-005 | Add gradient to featured blog card | 🟡 | 🟢 S | 🌐 Web | 📋 Todo |
 | HF-006 | Fix Card borders globally | 🔴 | 🟡 M | 🌐 Web | 📋 Todo |
-| HF-007 | Footer navigation titles yellow color | 🟡 | 🟢 S | 🌐 Web | 📋 Todo |
+| HF-007 | Footer navigation titles yellow color | 🟡 | 🟢 S | 🌐 Web | ✅ Done (2025-11-15) |
 | HF-008 | Footer Italian flag emoji | 🟢 | 🟢 S | 🌐 Web | 📋 Todo |
 | HF-009 | Footer MFDL branding | 🟡 | 🟢 S | 🌐 Web | 📋 Todo |
 

--- a/.backlog/epics/10-homepage-footer-fixes/epic.md
+++ b/.backlog/epics/10-homepage-footer-fixes/epic.md
@@ -61,7 +61,7 @@ Correggere tutte le inconsistenze visive e di contenuto nelle sezioni Homepage e
 - [ ] **HF-004** Update Flowing employment dates (🟢 S) - [Link](./stories/HF-004-flowing-dates.md)
 - [ ] **HF-005** Add gradient to featured blog card (🟢 S) - [Link](./stories/HF-005-featured-blog-gradient.md)
 - [ ] **HF-006** Fix Card borders globally (🟡 M) - [Link](./stories/HF-006-card-borders.md)
-- [ ] **HF-007** Footer navigation titles yellow color (🟢 S) - [Link](./stories/HF-007-footer-titles-yellow.md)
+- [x] **HF-007** Footer navigation titles yellow color (🟢 S) - [Link](./stories/HF-007-footer-titles-yellow.md) ✅ Done (2025-11-15)
 - [ ] **HF-008** Footer Italian flag emoji (🟢 S) - [Link](./stories/HF-008-footer-flag-emoji.md)
 - [ ] **HF-009** Footer MFDL branding (🟢 S) - [Link](./stories/HF-009-footer-mfdl.md)
 

--- a/.backlog/epics/10-homepage-footer-fixes/stories/HF-007-footer-titles-yellow.md
+++ b/.backlog/epics/10-homepage-footer-fixes/stories/HF-007-footer-titles-yellow.md
@@ -6,9 +6,10 @@
 - **Priorità**: 🟡 Media
 - **Dimensione**: 🟢 S (30min - 1h)
 - **Execution Environment**: 🌐 Claude Code Web
-- **Stato**: 📋 Todo
+- **Stato**: ✅ Done
 - **Assegnata a**: Claude Code
 - **Data Creazione**: 2025-11-15
+- **Data Completamento**: 2025-11-15 (Already completed in commit f9dcfa7)
 
 ---
 
@@ -143,3 +144,4 @@ grep -r "Risorse" app/ components/
 | Data | Modifiche | Stato |
 |------|-----------|-------|
 | 2025-11-15 | Story creata | Todo |
+| 2025-11-15 | Story verified as already completed in commit f9dcfa7 - Footer titles already using text-cyber-yellow | Done |


### PR DESCRIPTION
Story HF-007 verified as already completed in commit f9dcfa7. The footer section titles "Navigazione" and "Risorse" are already using text-cyber-yellow utility class in both IT and EN versions.

Changes:
- Updated story status: Todo → Done
- Added completion date: 2025-11-15
- Updated epic.md checklist
- Updated backlog.md master file

Reference: components/layout/Footer.tsx:113,133