### PR TITLE
[HF-008][HF-009] Add Italian flag emoji and MFDL branding

### DIFF
--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -155,7 +155,11 @@ export function Footer({ locale }: FooterProps) {
         {/* Bottom Bar */}
         <div className="flex flex-col md:flex-row justify-between items-center gap-4 text-sm text-white/60">
           <p className="flex items-center gap-2">
-            © {currentYear} Mattia De Luca. {t('madeWith')} ☕
+            © {currentYear}{' '}
+            <abbr title="Mattia Filippo De Luca" className="no-underline cursor-help">
+              MFDL
+            </abbr>
+            . {t('madeWith')} ☕
           </p>
           <div className="flex gap-6">
             <Link href={`/${locale}/privacy`} className="hover:text-cyber-yellow transition-colors">

--- a/components/ui/Header.tsx
+++ b/components/ui/Header.tsx
@@ -94,13 +94,14 @@ export function Header({ locale }: HeaderProps) {
                   if (locale !== 'it') toggleLocale();
                 }}
                 className={cn(
-                  'px-3 py-1.5 transition-all font-mono font-bold text-xs',
+                  'px-3 py-1.5 transition-all font-bold text-base',
                   locale === 'it'
                     ? 'bg-neon-pink text-white'
-                    : 'bg-transparent text-brutalist-text-secondary hover:bg-cream'
+                    : 'bg-transparent hover:bg-cream'
                 )}
+                aria-label="Italiano"
               >
-                IT
+                🇮🇹
               </button>
               <div className="w-px h-6 bg-black" />
               <button
@@ -108,13 +109,14 @@ export function Header({ locale }: HeaderProps) {
                   if (locale !== 'en') toggleLocale();
                 }}
                 className={cn(
-                  'px-3 py-1.5 transition-all font-mono font-bold text-xs',
+                  'px-3 py-1.5 transition-all font-bold text-base',
                   locale === 'en'
                     ? 'bg-neon-pink text-white'
-                    : 'bg-transparent text-brutalist-text-secondary hover:bg-cream'
+                    : 'bg-transparent hover:bg-cream'
                 )}
+                aria-label="English"
               >
-                EN
+                🇬🇧
               </button>
             </div>
 


### PR DESCRIPTION
Implements two footer/header hotfixes:

HF-008: Replace text language selector with flag emojis
- Replace "IT" with 🇮🇹 in Header language switcher
- Replace "EN" with 🇬🇧 in Header language switcher
- Add aria-label attributes for accessibility ("Italiano"/"English")
- Increase emoji font size from text-xs to text-base for visibility
- Remove font-mono class for better emoji rendering

HF-009: Add MFDL branding to footer
- Replace "Mattia De Luca" with "MFDL" in footer copyright
- Add <abbr> tag with "Mattia Filippo De Luca" tooltip for accessibility
- Maintain cursor-help styling on hover

Files changed:
- components/ui/Header.tsx (language selector with flag emojis)
- components/layout/Footer.tsx (MFDL branding with tooltip)