### PR TITLE
Fix language selector: replace flag emojis with text codes

### DIFF
--- a/components/ui/Header.tsx
+++ b/components/ui/Header.tsx
@@ -94,14 +94,14 @@ export function Header({ locale }: HeaderProps) {
                   if (locale !== 'it') toggleLocale();
                 }}
                 className={cn(
-                  'px-3 py-1.5 transition-all font-bold text-base',
+                  'px-3 py-1.5 transition-all font-bold text-sm',
                   locale === 'it'
                     ? 'bg-neon-pink text-white'
-                    : 'bg-transparent hover:bg-cream'
+                    : 'bg-transparent hover:bg-cream text-brutalist-text-secondary'
                 )}
                 aria-label="Italiano"
               >
-                🇮🇹
+                IT
               </button>
               <div className="w-px h-6 bg-black" />
               <button
@@ -109,14 +109,14 @@ export function Header({ locale }: HeaderProps) {
                   if (locale !== 'en') toggleLocale();
                 }}
                 className={cn(
-                  'px-3 py-1.5 transition-all font-bold text-base',
+                  'px-3 py-1.5 transition-all font-bold text-sm',
                   locale === 'en'
                     ? 'bg-neon-pink text-white'
-                    : 'bg-transparent hover:bg-cream'
+                    : 'bg-transparent hover:bg-cream text-brutalist-text-secondary'
                 )}
                 aria-label="English"
               >
-                🇬🇧
+                EN
               </button>
             </div>
 


### PR DESCRIPTION
Changed from 🇮🇹/🇬🇧 to IT/EN for better clarity and semantic correctness. Also improved styling with text-sm and text-brutalist-text-secondary.