### PR TITLE
Fix design system import generation for default exports

### DIFF
--- a/lib/design-system/component-parser.ts
+++ b/lib/design-system/component-parser.ts
@@ -180,9 +180,13 @@ export function parseComponent(sourceFile: SourceFile, filePath: string): Compon
   const mainPropsInterface = propsInterfaces.find(i => i.getName() === `${fileName}Props`) || propsInterfaces[0];
 
   // Extract all exported components from the file
-  const exportedComponents = sourceFile
+  const allExportedSymbols = sourceFile
     .getExportSymbols()
-    .map(s => s.getName())
+    .map(s => s.getName());
+
+  const hasDefaultExport = allExportedSymbols.includes('default');
+
+  const exportedComponents = allExportedSymbols
     .filter(name => name !== 'default' && !name.endsWith('Props'));
 
   const mainComponentName = exportedComponents.includes(fileName)
@@ -236,6 +240,7 @@ export function parseComponent(sourceFile: SourceFile, filePath: string): Compon
     variants,
     examples,
     subComponents: subComponents.length > 0 ? subComponents : undefined,
+    isDefaultExport: hasDefaultExport && exportedComponents.length === 0,
   };
 }
 

--- a/lib/design-system/doc-generator.ts
+++ b/lib/design-system/doc-generator.ts
@@ -222,11 +222,18 @@ export function generateImportStatements(components: ComponentMetadata[]): strin
   const imports = components.map(comp => {
     const relativePath = comp.filePath.replace(/\\/g, '/').replace(/^.*\/components\//, '@/components/').replace('.tsx', '');
 
+    // For components with sub-components, always use named imports
     if (comp.subComponents && comp.subComponents.length > 0) {
       const allComponents = [comp.name, ...comp.subComponents.map(sub => sub.name)];
       return `import { ${allComponents.join(', ')} } from '${relativePath}';`;
     }
 
+    // For components with default export, use default import
+    if (comp.isDefaultExport) {
+      return `import ${comp.name} from '${relativePath}';`;
+    }
+
+    // Otherwise, use named import
     return `import { ${comp.name} } from '${relativePath}';`;
   });
 

--- a/lib/design-system/types.ts
+++ b/lib/design-system/types.ts
@@ -41,6 +41,7 @@ export interface ComponentMetadata {
   variants: VariantDefinition[];
   examples: ExampleCode[];
   subComponents?: ComponentMetadata[]; // For compound components like Card
+  isDefaultExport?: boolean; // Whether the component uses default export
 }
 
 /**


### PR DESCRIPTION
Problem:
The design system generator was creating named imports ({ Component }) for all components, but some components (CTAButton, CertificationModal, TestimonialModal) use default exports, causing TypeScript errors: "Module has no exported member 'Component'"

Solution:
1. Added `isDefaultExport` field to ComponentMetadata type
2. Updated parser to detect when a component uses default export
3. Updated generator to create correct import syntax:
   - Default import for components with default export
   - Named imports for components with named exports
   - Named imports for compound components (Card, Section, etc.)

Changes:
- lib/design-system/types.ts: Added isDefaultExport field
- lib/design-system/component-parser.ts: Detect default exports
- lib/design-system/doc-generator.ts: Generate correct import syntax

This fixes the build error where TypeScript couldn't find exported members.