### PR TITLE
Improve component detection to filter out TypeScript interfaces

### DIFF
--- a/lib/design-system/component-parser.ts
+++ b/lib/design-system/component-parser.ts
@@ -186,12 +186,22 @@ export function parseComponent(sourceFile: SourceFile, filePath: string): Compon
 
   const hasDefaultExport = allExportedSymbols.includes('default');
 
+  // Filter out: default, Props interfaces, Data interfaces (usually types, not components)
   const exportedComponents = allExportedSymbols
-    .filter(name => name !== 'default' && !name.endsWith('Props'));
+    .filter(name =>
+      name !== 'default' &&
+      !name.endsWith('Props') &&
+      !name.endsWith('Data') &&
+      !name.startsWith('use') // Exclude hooks
+    );
 
-  const mainComponentName = exportedComponents.includes(fileName)
+  // Prefer the fileName as main component if it exists, or use first exported
+  // If default export exists and no named components, use fileName
+  const mainComponentName = hasDefaultExport && exportedComponents.length === 0
     ? fileName
-    : exportedComponents[0] || fileName;
+    : exportedComponents.includes(fileName)
+      ? fileName
+      : exportedComponents[0] || fileName;
 
   // Extract metadata
   const variants = extractVariants(mainPropsInterface);


### PR DESCRIPTION
Enhanced the component parser to better distinguish between actual React components and TypeScript type definitions:

1. Filter out exports ending with 'Data' (e.g., CertificationData, TestimonialData)
2. Filter out hook exports starting with 'use' (e.g., useGoogleCalendar)
3. Improved logic for determining main component name:
   - For default exports with no named components, use fileName
   - Otherwise, prefer fileName if it exists in exports
   - Fallback to first exported component

This prevents the parser from treating type definitions as components, which was causing incorrect categorization and potentially confusing import generation.

Before: CertificationData and TestimonialData were treated as components
After: CertificationBadge and Testimonial are correctly identified

This makes the parser more robust and less prone to errors when components export both the component and related TypeScript types.