### PR TITLE
fix: use npx to run tsx in generate script for Netlify compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:vitest:ui": "vitest --ui",
     "lighthouse": "lhci autorun",
     "playwright:install": "playwright install --with-deps",
-    "generate:design-system": "tsx scripts/generate-design-system.ts"
+    "generate:design-system": "npx tsx scripts/generate-design-system.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.30.1",


### PR DESCRIPTION
The Netlify build was failing because the tsx binary wasn't found in PATH during build. Using npx ensures the command is properly resolved from node_modules/.bin/

Fixes: sh: 1: tsx: not found error in Netlify build