### PR TITLE
fix(styles): define missing text-brutalist-text-primary class

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -208,6 +208,12 @@
 }
 
 /* Text color utilities for grays */
+.text-brutalist-text-primary,
+.text-\[\#0A0A0A\] {
+  color: #0A0A0A;
+}
+
+.text-brutalist-text-secondary,
 .text-secondary,
 .text-\[\#2D2D2D\] {
   color: #2D2D2D;
@@ -216,10 +222,6 @@
 .text-tertiary,
 .text-\[\#6B7280\] {
   color: #6B7280;
-}
-
-.text-\[\#0A0A0A\] {
-  color: #0A0A0A;
 }
 
 /* Link color utilities - override font-bold default */


### PR DESCRIPTION
Fixed white text issue on "Quello che ascolto per davvero" title by adding the missing text-brutalist-text-primary and text-brutalist-text-secondary CSS classes that were referenced in 9 components but never defined.

- Added .text-brutalist-text-primary with color #0A0A0A (black)
- Added .text-brutalist-text-secondary for consistency
- Affects ActivityCard, ExperienceCard, CollaborationCard, and other components